### PR TITLE
add bootstrap to the bower setup list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,8 @@
     "paper-material": "^1.0.6",
     "paper-card": "PolymerElements/paper-card#^1.1.4",
     "polymer-global-variables": "^1.1.0",
-    "iron-iconset": "^1.0.5"
+    "iron-iconset": "^1.0.5",
+    "polymer-bootstrap": "0.1.2"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0",


### PR DESCRIPTION
In order to use the Bootstrap additions the builder needs the polymer bootstrap backend
