### PR TITLE
DIO-577: have a max width of images on large screens

### DIFF
--- a/src/atoms/dorel-image-wrap.html
+++ b/src/atoms/dorel-image-wrap.html
@@ -7,6 +7,7 @@
       .image-wrap img {
         margin: 0 auto;
         width: 100%;
+        max-width: 340px;
       }
     </style>
     

--- a/src/organisms/dorel-section-multi.html
+++ b/src/organisms/dorel-section-multi.html
@@ -15,11 +15,6 @@
         margin-bottom: 6rem;
         width: 100%;
       }
-
-      .section-multi[desktopSmall] .image-wrap img,
-      .section-multi[desktopFull] .image-wrap img {
-        max-width: 340px;
-      }
     </style>
     
     <!-- media queries -->

--- a/src/organisms/dorel-section-multi.html
+++ b/src/organisms/dorel-section-multi.html
@@ -15,6 +15,11 @@
         margin-bottom: 6rem;
         width: 100%;
       }
+
+      .section-multi[desktopSmall] .image-wrap img,
+      .section-multi[desktopFull] .image-wrap img {
+        max-width: 340px;
+      }
     </style>
     
     <!-- media queries -->


### PR DESCRIPTION
Hey @mrpharderwijk,

Kan je kijken of deze werkt voordat je hem merged? 

Zie hier de oude situatie waar de images de volledige breedte hebben:
https://australia.dorel-app.net/products/hera-isogo/

De expected outcome is:
<img width="1602" alt="screen shot 2017-04-03 at 11 57 04" src="https://cloud.githubusercontent.com/assets/9882035/24604351/b8991de4-1864-11e7-90e6-11e08d1fe67d.png">
