### PR TITLE
DIO-1993 hide next button in slideshow when single slide

### DIFF
--- a/src/organisms/dorel-section-slideshow.html
+++ b/src/organisms/dorel-section-slideshow.html
@@ -115,7 +115,8 @@
           type: Object,
           value: function () {
             return {};
-          }
+          },
+          observer: '_slideshowDataChanged'
         },
 
         /**
@@ -191,7 +192,13 @@
         } else {
           this.set('previousEnabled', true);
         }
-      }
+      },
+
+      _slideshowDataChanged: function() {
+        var slides = this.get('slideshowData.slides') || [];
+        this.set('nextEnabled', !!(slides.length > 1));
+      },
+
     });
   </script>
 </dom-module>


### PR DESCRIPTION
change mock slideshow.js so you have only one slide, no nextslide button will be shown