### PR TITLE
Bugfix.DIO-3105: fixed unreadable text in faq promo

### DIFF
--- a/src/organisms/dorel-section-service-faq-promo.html
+++ b/src/organisms/dorel-section-service-faq-promo.html
@@ -68,7 +68,7 @@
                           height="8em"></dorel-bynder-image>
       <div class="text-container">
         <h3 class="title">[[ templateData.title ]]</h3>
-        <h4>[[ templateData.description ]]</h4>
+        <p>[[ templateData.description ]]</p>
       </div>
 
       <template is="dom-if" if="[[ light ]]">


### PR DESCRIPTION
Changed h4 to p in service faq promo to fix text color issue and have semantic HTML (a piece of text is not a heading).